### PR TITLE
Fixed title of extension link in left menu

### DIFF
--- a/settings/menu.ini.append.php
+++ b/settings/menu.ini.append.php
@@ -2,5 +2,6 @@
 
 [Leftmenu_setup]
 Links[_script_monitor]=/scriptmonitor/list
+LinkNames[_script_monitor]=Script monitor
 
 */ ?>


### PR DESCRIPTION
LinkNames is missing, so the setup left menu shows "_script_monitor" when the extension is activated. The fix changes this to "Script monitor".
