### PR TITLE
Protection against too long command to avoid bad code injection in shell

### DIFF
--- a/classes/ezscheduledscript.php
+++ b/classes/ezscheduledscript.php
@@ -50,6 +50,9 @@ class eZScheduledScript extends eZPersistentObject
             return false;
         }
 
+        $name = trim( $name );
+        $command = trim( $command );
+
         if ( !$userID )
         {
             $userID = eZUser::currentUserID();
@@ -59,6 +62,12 @@ class eZScheduledScript extends eZPersistentObject
         $scriptSiteAccess = $scriptMonitorIni->variable( 'GeneralSettings', 'ScriptSiteAccess' );
         $command = str_replace( self::SCRIPT_NAME_STRING, $name, $command );
         $command = str_replace( self::SITE_ACCESS_STRING, $scriptSiteAccess, $command );
+
+        if ( strlen( $command ) > 2000 )
+        {
+            eZDebug::writeError( 'Your command string is too long, it must be less than 2000 characters.', 'ezscriptmonitor' );
+            return false;
+        }
 
         // Negative progress means not started yet
         return new self( array( 'name' => $name,


### PR DESCRIPTION
It's possible to invoke ezscriptmonitor with a big big command line, but if the command is longer than 2000, it will be silently cut by the database (length for this command has been increased from 255 to 2000 with https://github.com/ezsystems/ezscriptmonitor/pull/8, but whatever the limit is, even huge, protection is required)

When the cronjob executes this command, it will execute a command, that has been cut just after 2000 chars...

So with a command like "./prog --command='echo "[massive spaces]"; rm -rf /' --scriptid=4"...
Well... you know... :)
